### PR TITLE
Add images dir so app can start without error

### DIFF
--- a/assets/images/.gitignore
+++ b/assets/images/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
So this doesn't happen at startup

```
warning: ignoring extraneous `ruby-' prefix in version `ruby-2.1.2'
         (set by /Users/stevend/src/mandrill-merge/.ruby-version)
/opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/options.rb:90:in `serve': Not a directory - /Users/stevend/src/mandrill-merge/assets/images (Errno::ENOTDIR)
    from /Users/stevend/src/mandrill-merge/app.rb:15:in `block in <class:App>'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/options.rb:76:in `instance_eval'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/options.rb:76:in `initialize'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/class_methods.rb:7:in `new'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/class_methods.rb:7:in `assets'
    from /Users/stevend/src/mandrill-merge/app.rb:12:in `<class:App>'
    from /Users/stevend/src/mandrill-merge/app.rb:8:in `<top (required)>'
    from /opt/rubies/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /opt/rubies/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/stevend/src/mandrill-merge/config.ru:3:in `block in <main>'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
    from /Users/stevend/src/mandrill-merge/config.ru:in `new'
    from /Users/stevend/src/mandrill-merge/config.ru:in `<main>'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
    from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.1.2/bin/rackup:23:in `load'
    from /opt/boxen/rbenv/versions/2.1.2/bin/rackup:23:in `<main>'
```
