### PR TITLE
Correlate merge field data

### DIFF
--- a/assets/scripts/mandrill_merge.coffee
+++ b/assets/scripts/mandrill_merge.coffee
@@ -63,7 +63,7 @@ class MandrillMergeApp
     MandrillMerge.app.clear_section_status('select_data')
     if response.success
       MandrillMerge.app.mark_section_complete('select_data')
-      MandrillMerge.app.toggle_section 'sub_query'
+      MandrillMerge.app.toggle_section 'send_test'
     else
       MandrillMerge.app.mark_section_error('select_data')
 

--- a/assets/scripts/mandrill_merge.coffee
+++ b/assets/scripts/mandrill_merge.coffee
@@ -35,6 +35,11 @@ class MandrillMergeApp
   go_forward: (caller)->
     caller.parents('.accordion-navigation').next().find('a').click()
 
+  // This is a hack to get a tab to go directly to the send_test tab when it is not the next in line
+  // Its hack week after all... until we come up with a better way to handle the UI workflow
+  send_test: (caller)->
+    MandrillMerge.app.toggle_section('send_test')
+
   mandrill_connect_response: (response)->
     $('#mandrill-connection-status').html response.message
 

--- a/assets/scripts/mandrill_merge.coffee
+++ b/assets/scripts/mandrill_merge.coffee
@@ -41,6 +41,7 @@ class MandrillMergeApp
     $('#mandrill-template-status').html response.message
     MandrillMerge.app.clear_section_status('select_template')
     if response.success
+      $('#merge-tags-list').html(response.merge_tags)
       MandrillMerge.app.mark_section_complete('select_template')
       MandrillMerge.app.toggle_section 'connect_db'
     else

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -13,4 +13,5 @@ class MessageBuilder
       message: message 
     }  
   end
+
 end

--- a/lib/template_field_merger.rb
+++ b/lib/template_field_merger.rb
@@ -1,0 +1,16 @@
+class TemplateFieldMerger
+
+  def self.merge_fields(merge_fields, db_rows)
+    merged_template_rows = []
+    db_rows.each do |row|
+      row.shift(2) # id and email fields are not merge fields
+      merged_row_fields = []
+      merge_fields.each_with_index do |tag, i|
+        merged_row_fields << { name: tag, content: row[i] }
+      end
+      merged_template_rows << merged_row_fields
+    end
+    merged_template_rows
+  end
+
+end

--- a/routes.rb
+++ b/routes.rb
@@ -40,7 +40,16 @@ class App < Sinatra::Application
       response = mandrill.fetch_merge_tags(params[:template])
       session[:template] = params[:template]
       session[:merge_tags] = response unless response.empty?
-      {success: true, message: session[:template]}
+
+      if session[:merge_tags]
+        merge_tags_list = "Unique ID, Recipient Email, "
+        session[:merge_tags].each do |tag|
+          merge_tags_list << "#{tag}, "
+        end
+        merge_tags_list = merge_tags_list[0..-3]
+      end
+
+      {success: true, message: session[:template], merge_tags: merge_tags_list||''}
     rescue StandardError => e
       {success: false, message: e.message}    
     end.to_json

--- a/spec/lib/template_field_merger_spec.rb
+++ b/spec/lib/template_field_merger_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe TemplateFieldMerger do
+
+  let(:template_fields) { ['FIRSTNAME', 'SURNAME'] }
+  let(:database_rows) do 
+    [
+      ['1', 'test@example.com',  'FRED', 'BASSETT'],
+      ['2', 'test2@example.com', 'HANS', 'OLO']
+    ]
+  end
+
+  subject(:merged_fields) { TemplateFieldMerger.merge_fields(template_fields, database_rows) }
+
+  it 'should contain two merged rows' do
+    expect(merged_fields.size).to be 2
+  end
+
+  it 'should merge each database row into an array of hashes' do
+    expected_structure = [
+      [{ name: 'FIRSTNAME', content: 'FRED' }, { name: 'SURNAME', content: 'BASSETT' }],
+      [{ name: 'FIRSTNAME', content: 'HANS' }, { name: 'SURNAME', content: 'OLO' }]
+    ]
+    expect(merged_fields).to eq expected_structure
+  end
+
+end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -120,8 +120,14 @@ describe 'routes' do
 
     let(:params) {}
     let(:session) {}
+    let(:reader) { double('reader').as_null_object }
 
-    before { post '/send-test', params, 'rack.session' => session }
+    before do
+      Database.stub_chain(:connection, :create_command, :execute_reader).and_return(reader)
+      allow(TemplateFieldMerger).to receive(:merge_fields).and_return([])
+
+      post '/send-test', params, 'rack.session' => session
+    end
 
     context 'when session contains the mandrill key and template name' do
       let(:session) { {key: 'key', template: 'template'} }

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -36,7 +36,8 @@ describe 'routes' do
       before { post '/select-template', {:template => 'the_template'}, 'rack.session' => {key: 'key'} }
 
       context 'with merge tags' do
-        let(:mandrill) { double(Mandrill, fetch_merge_tags: ['TAG1', 'TAG2']) }
+        let(:merge_tags) { ['TAG1', 'TAG2'] }
+        let(:mandrill) { double(Mandrill, fetch_merge_tags: merge_tags) }
 
         it 'succeeds' do
           expect(json_hash['success']).to be true
@@ -47,7 +48,7 @@ describe 'routes' do
         end
 
         it 'saves the merge tags in the session' do
-          # how to test??
+          expect(json_hash['merge_tags']).to include merge_tags.join(', ')
         end
       end
 

--- a/views/_navigation.erb
+++ b/views/_navigation.erb
@@ -1,6 +1,6 @@
 <div class="clearfix">
   <% if locals[:on_back] %>
-    <a role="button" href="#" class="button nav-button back left" onclick="MandrillMerge.app.<%= on_back  %>($(this))">Back</a>
+    <a role="button" href="#" class="button nav-button back left" onclick="MandrillMerge.app.<%= on_back %>($(this))">Back</a>
   <% end %>
   <% if locals[:on_next] %>
     <a role="button" href="#" class="button nav-button next right" onclick="MandrillMerge.app.<%= on_next %>($(this))">Next</a>

--- a/views/_select_data_body.erb
+++ b/views/_select_data_body.erb
@@ -1,4 +1,4 @@
-<p>Your SQL should return the following columns:</p>
+Your SQL should return the following columns:
 <div id="merge-tags-list">
   Unique ID, Recipient Email, <%= @merge_tags.join(', ') %>
 </div>

--- a/views/_select_data_body.erb
+++ b/views/_select_data_body.erb
@@ -19,4 +19,4 @@ Your SQL should return the following columns:
   </div>
 </div>
 
-<%= partial(:navigation, :locals => { on_back: "go_back", on_next: "go_forward"}) %>
+<%= partial(:navigation, :locals => { on_back: "go_back", on_next: "send_test"}) %>

--- a/views/_select_data_body.erb
+++ b/views/_select_data_body.erb
@@ -1,4 +1,8 @@
-<p>Your SQL should return the following columns: Unique ID, Recipient Email, <%= @merge_tags.join(', ') %></p>
+<p>Your SQL should return the following columns:</p>
+<div id="merge-tags-list">
+  Unique ID, Recipient Email, <%= @merge_tags.join(', ') %>
+</div>
+
 <form action="/set-db-query" method="post" ajax-form ajax-callback="set_db_query_response">
   <textarea name="db_query" placeholder="Enter your query"><%= @db_query %></textarea>
 </form>


### PR DESCRIPTION
First cut of merging template fields/placeholders with data retrieved from the database query.

Note that currently we are mapping placeholders to db fields in placeholder order. Which means whatever order the placeholders are, its going to pick the corresponding field in the database rows.
This is done starting from the third field in the database row as the first two fields in the database row are the User ID and the User email address.

In future we would potentially change this to allow the user to do the mapping themselves in the UI.

The other change here is to populate the select data tab with the template placeholder fields when a template is selected.